### PR TITLE
undefined variable ref; jupyter formatting

### DIFF
--- a/serve-hf-llm-with-caikit.ipynb
+++ b/serve-hf-llm-with-caikit.ipynb
@@ -187,7 +187,7 @@
     "\n",
     "if not safetensor_files_exist:\n",
     "    print(\"No .safetensors files found. Starting conversion...\")\n",
-    "    !./convert.py --model-path ./$MODEL_NAME --model-save-path ./$MODEL_NAME-$CONVERTED_PATH_ADDITION\n",
+    "    !./convert.py --model-path ./\\$MODEL_NAME --model-save-path ./\\$MODEL_NAME-$CONVERTED_PATH_ADDITION\n",
     "else:\n",
     "    print(\"Model already converted to .safetensors format.\")\n"
    ]

--- a/serve-hf-llm-with-caikit.ipynb
+++ b/serve-hf-llm-with-caikit.ipynb
@@ -318,11 +318,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def upload_directory_to_s3(local_directory, s3_prefix):\n",
-    "    for root, dirs, files in os.walk(local_directory):\n",
+    "def upload_directory_to_s3(model_directory, s3_prefix):\n",
+    "    for root, dirs, files in os.walk(model_directory):\n",
     "        for filename in files:\n",
     "            file_path = os.path.join(root, filename)\n",
-    "            relative_path = os.path.relpath(file_path, local_directory)\n",
+    "            relative_path = os.path.relpath(file_path, model_directory)\n",
     "            s3_key = os.path.join(s3_prefix, relative_path)\n",
     "            print(f\"{file_path} -> {s3_key}\")\n",
     "            bucket.upload_file(file_path, s3_key)"


### PR DESCRIPTION
- swap references of `local_directory` to `model_directory` (defined earlier in .ipynb) at S3 upload
- escape `$` to avoid mathjax formatting